### PR TITLE
feat(gui): wait and show fyne-based client error message after the client is started

### DIFF
--- a/client-ui/main.go
+++ b/client-ui/main.go
@@ -99,9 +99,11 @@ func main() {
 
 	btnStatus := btnStopped
 	var handles extra.TaskHandles
+	var ignoreWaitErr = true
 	btnStart.OnTapped = func() {
 		if btnStatus == btnRunning { // running can stop
 			btnStatus = btnStopping
+			ignoreWaitErr = true
 			btnStart.SetText("Stopping")
 			handles.NotifyCloseWrapper()
 			btnStart.SetText("Start")
@@ -135,6 +137,17 @@ func main() {
 			}
 			btnStart.SetText("Stop")
 			btnStatus = btnRunning
+			go func() {
+				// the `ignoreWaitErr` the same as swiftui.
+				ignoreWaitErr = false
+				// wait error and stop the client
+				if err := handles.Wait(); err != nil && !ignoreWaitErr {
+					dialog.ShowError(err, w)
+				}
+				btnStart.SetText("Start")
+				btnStatus = btnStopped
+				ignoreWaitErr = true
+			}()
 		}
 	}
 


### PR DESCRIPTION
After the fyne-based client is started, we call api handles.Wait() to wait error and show error message dialog if there is some error while running (e.g. connection lost or listern port already in used).
This commit is similar as PR #12. This is for the fyne-based client, while #12 is for swiftui client.