### PR TITLE
ci(gh-action): bump action upload-artifact, download-artifact to v4 and action-gh-release to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           cd ../
           mv client-ui/client-ui-windows-amd64.exe client-ui-windows-amd64.exe
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: build-artifact-${{ matrix.os }}
           path: ${{ matrix.artifact_files }}
@@ -70,19 +70,19 @@ jobs:
     needs: build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: build-artifact-ubuntu-22.04
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: build-artifact-windows-2022
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: build-artifact-macos-12
       - run: ls -R
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |


### PR DESCRIPTION
Note: v1 and v2 of the artifact actions is deprecated in 2024/03. We must use the new version ofartifact actions.